### PR TITLE
fix multi param dcu. add password support.

### DIFF
--- a/Proactive Remediation/DELL Driver Updates/remediate_DELLUpdates.ps1
+++ b/Proactive Remediation/DELL Driver Updates/remediate_DELLUpdates.ps1
@@ -2,9 +2,11 @@ $DCU_folder = "C:\Program Files (x86)\Dell\CommandUpdate"
 $DCU_report = "C:\Temp\Dell_report\update.log"
 $DCU_exe = "$DCU_folder\dcu-cli.exe"
 $DCU_category = "firmware,driver"  # bios,firmware,driver,application,others
+$DCU_encryptionKey = "ADD ENC KEY" # Use the same value here as you use in /generateEncryptedPassword -encryptionKey=
+$DCU_encryptedPassword = "ADD ENC PWD" # Generate with dcu-cli.exe /generateEncryptedPassword -encryptionKey=<inline value> -password=<inlinevalue> -outputPath=<folderpath>
 
 try{
-    Start-Process $DCU_exe -ArgumentList "/applyUpdates -silent -reboot=disable -updateType=$DCU_category -outputlog=$DCU_report /configure -silent -autoSuspendBitLocker=enable -userConsent=disable" -Wait
+    Start-Process $DCU_exe -ArgumentList "/applyUpdates -silent -reboot=disable -updateType=$DCU_category -outputlog=$DCU_report -autoSuspendBitLocker=enable -encryptedPassword=$DCU_encryptedPassword -encryptionKey=$DCU_encryptionKey" -Wait
     Write-Output "Installation completed"
 }catch{
     Write-Error $_.Exception


### PR DESCRIPTION
DCU doesn't support multiple params that start with /.  removed config as autosuspendbitlocker still works with /applyupdates.
Added params for bios passwords.