### PR TITLE
Update install.ps1

### DIFF
--- a/Program - win32/Microsoft Teams (new)/install.ps1
+++ b/Program - win32/Microsoft Teams (new)/install.ps1
@@ -24,10 +24,15 @@ function Uninstall-TeamsClassic($TeamsPath) {
 
 # Remove Teams Machine-Wide Installer
 Write-Host "Removing Teams Machine-wide Installer"
-$MachineWide = Get-WmiObject -Class Win32_Product | Where-Object { $_.Name -eq "Teams Machine-Wide Installer" }
+
+#Windows Uninstaller Registry Path
+$registryPath = "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*"
+
+# Get all subkeys and match the subkey that contains "Teams Machine-Wide Installer" DisplayName.
+$MachineWide = Get-ItemProperty -Path $registryPath | Where-Object -Property DisplayName -eq "Teams Machine-Wide Installer"
 
 if ($MachineWide) {
-    $MachineWide.Uninstall()
+    Start-Process -FilePath "msiexec.exe" -ArgumentList "/x ""$($MachineWide.PSChildName)"" /qn" -NoNewWindow -Wait
 }
 else {
     Write-Host "Teams Machine-Wide Installer not found"


### PR DESCRIPTION
Updated to move away from Win32 class as it causes Windows to check and potentially modify software.

https://gregramsey.net/2012/02/20/win32_product-is-evil/

This now uses a dynamic registry search to find the uninstall string and passes it to msiexec.exe to uninstall.